### PR TITLE
Add typing indicator for tags

### DIFF
--- a/src/commands/misc/tag.js
+++ b/src/commands/misc/tag.js
@@ -40,7 +40,7 @@ class TagCommand extends Command {
     context.message.channel.startTyping(1);
     const parsed = await this.client.lisa.parseString(context, tag.content, 'tag', args);
     context.reply(parsed.content || '', { embed: parsed.embed });
-    context.message.channel.stopTyping(true)
+    context.message.channel.stopTyping(true);
   }
 }
 

--- a/src/commands/misc/tag.js
+++ b/src/commands/misc/tag.js
@@ -37,7 +37,7 @@ class TagCommand extends Command {
       return context.replyWarning(context.__('tag.nsfwAlert'));
     }
 
-    context.message.channel.startTyping(1);
+    await context.message.channel.startTyping(1);
     const parsed = await this.client.lisa.parseString(context, tag.content, 'tag', args);
     context.reply(parsed.content || '', { embed: parsed.embed });
     context.message.channel.stopTyping(true);
@@ -310,8 +310,10 @@ class ExecSubcommand extends Command {
     const content = context.args.join(' ');
     if (!content) return context.replyError(context.__('tag.exec.noContent'));
 
+    await context.message.channel.startTyping(1);
     const parsed = await this.client.lisa.parseString(context, content, 'tag');
     context.reply(parsed.content || '', { embed: parsed.embed });
+    context.message.channel.stopTyping(true);
   }
 }
 

--- a/src/commands/misc/tag.js
+++ b/src/commands/misc/tag.js
@@ -37,8 +37,10 @@ class TagCommand extends Command {
       return context.replyWarning(context.__('tag.nsfwAlert'));
     }
 
+    context.message.channel.startTyping(1);
     const parsed = await this.client.lisa.parseString(context, tag.content, 'tag', args);
     context.reply(parsed.content || '', { embed: parsed.embed });
+    context.message.channel.stopTyping(true)
   }
 }
 


### PR DESCRIPTION
Might be good for tags that use {http:} and thus might take multiple seconds to return







Disclaimer: I didn't test this